### PR TITLE
Fix client component setup and config typings

### DIFF
--- a/src/app/commonContext.ts
+++ b/src/app/commonContext.ts
@@ -1,9 +1,16 @@
+"use client";
+
 import React, { createContext, useReducer, useEffect, useCallback } from "react";
 import axios from "axios";
 
 // --- 필요한 상수들 (코드, 경로 등)
-const APP_CONFIG = window.$APP_CONFIG || {}; // 혹은 import ...
-const CODES_CONFIG = window.$CODES_CONFIG || {}; // 혹은 import ...
+const APP_CONFIG = (window as any).$APP_CONFIG || {}; // 혹은 import ...
+const CODES_CONFIG = (window as any).$CODES_CONFIG || {}; // 혹은 import ...
+
+// 광고/네비게이션용 디스플레이 아이디 매핑
+const DISPLAY_ID: Record<string, string[]> = {
+  greenjuice: ["GJ", "New", "Event", "Guide"],
+};
 
 // --- 초기 상태
 const initialState = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,9 @@
+"use client";
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import { CommonProvider } from "./commonContext";
+import { CommonProvider } from "./app/commonContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 

--- a/src/shared/config/settings.config.ts
+++ b/src/shared/config/settings.config.ts
@@ -19,16 +19,18 @@ interface Settings {
 	};
 }
 export const APP_SETTINGS: Settings = {
-	brand_list: {
-		ORGA: "orga",
-		PULMUONE: "pulmuone",
-		GREENJUICE: "greenjuice",
-	},
-	mallName: "PulmuoneMall",
-	userSession: "",
-	layoutOptions: {
-		useHeader: true,
-		useFooter: true,
+        title: "Pulmuone Mall App",
+        brand_list: {
+                ORGA: "orga",
+                PULMUONE: "pulmuone",
+                GREENJUICE: "greenjuice",
+        },
+        mallName: "PulmuoneMall",
+        userSession: "",
+        layout: "default",
+        layoutOptions: {
+                useHeader: true,
+                useFooter: true,
 		title: "풀무원#",
 		headerType: "sub",
 		brand: "MALL_DIV.PULMUONE",

--- a/src/widgets/layouts/Gnb.tsx
+++ b/src/widgets/layouts/Gnb.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 // Gnb.jsx
 import React, { useContext, useEffect, useState } from "react";
-import { CommonContext } from "./commonContext";
+import { CommonContext } from "@/app/commonContext";
 
 const BRAND_LIST = {
   ORGA: "orga",


### PR DESCRIPTION
## Summary
- mark Gnb component and CommonContext as client components
- correct CommonContext import path in Gnb and index files
- add missing title and layout fields to app settings

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3e07dad48329a41595753ac29ed0