### PR TITLE
Add AuthProvider and fix SCSS variable import

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
 	},
 	"dependencies": {
 		"next": "15.4.2",
+		"next-auth": "^4.22.1",
+		"next-themes": "^0.4.6",
 		"react": "19.1.0",
 		"react-dom": "19.1.0",
 		"sass": "^1.89.2"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Header from "@/widgets/layouts/Header.tsx";
 import Footer from "@/widgets/layouts/Footer.tsx";
 import ThemeProvider from "./providers/ThemeProvider";
 import { SettingsProvider } from "./providers/SettingsProvider";
+import { AuthProvider } from "./providers/AuthProvider";
 // import { CommonProvider } from "./commonContext";
 
 export const metadata = {
@@ -15,20 +16,22 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
 	return (
-		<html lang="ko" suppressHydrationWarning>
-			<body>
-				<SettingsProvider>
-					<ThemeProvider>
-						{/* <CommonProvider> */}
-						<Header />
-						<main style={{ minHeight: "calc(100vh - 160px)" }}>
-							{children} {/* 페이지 컨텐츠 */}
-						</main>
-						<Footer />
-						{/* </CommonProvider> */}
-					</ThemeProvider>
-				</SettingsProvider>
-			</body>
-		</html>
+                <html lang="ko" suppressHydrationWarning>
+                        <body>
+                                <AuthProvider>
+                                        <SettingsProvider>
+                                                <ThemeProvider>
+                                                        {/* <CommonProvider> */}
+                                                        <Header />
+                                                        <main style={{ minHeight: "calc(100vh - 160px)" }}>
+                                                                {children} {/* 페이지 컨텐츠 */}
+                                                        </main>
+                                                        <Footer />
+                                                        {/* </CommonProvider> */}
+                                                </ThemeProvider>
+                                        </SettingsProvider>
+                                </AuthProvider>
+                        </body>
+                </html>
 	);
 }

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+  session?: Session | null;
+}
+
+export function AuthProvider({ children, session }: AuthProviderProps) {
+  const basePath =
+    (typeof window !== 'undefined'
+      ? process.env.NEXT_PUBLIC_BASE_PATH
+      : process.env.NEXT_PUBLIC_BASE_PATH) || '';
+  return (
+    <SessionProvider session={session} basePath={`${basePath}/api/auth`}>
+      {children}
+    </SessionProvider>
+  );
+}

--- a/src/shared/styles/utils/colors.scss
+++ b/src/shared/styles/utils/colors.scss
@@ -1,3 +1,4 @@
+@use "../common/variable.scss" as *;
 // #endregion
 $colors: (
 	black: $black,


### PR DESCRIPTION
## Summary
- add `AuthProvider` with `next-auth`
- wrap layout content with `AuthProvider`
- fix variable imports in `colors.scss`
- update dependencies

## Testing
- `npm run lint` *(fails: Parsing error in commonContext.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68803f39da248329bb195f740e386958